### PR TITLE
Proc.new内でbreakするとLocalJumpErrorが発生するため、storeが一致する場合はsafe_runをスキップするようにした

### DIFF
--- a/mrblib/connection.rb
+++ b/mrblib/connection.rb
@@ -43,11 +43,10 @@ module Msd
       stores.each do |s|
         safe_run(
           Proc.new {
-            break if s == klass
             s.cache(key, value)
           },
           Proc.new { s.before_cache_retry }
-        )
+        ) if s == klass
       end
     end
 


### PR DESCRIPTION
表題通りの修正をしています。

以前のmrubyバージョンでは通っていましたが、cruby仕様に追いつきエラーでコケるようになっておりました。
https://docs.ruby-lang.org/ja/latest/class/Proc.html