### PR TITLE
クラス判定処理に誤りがあり、キー発見時に他のstoreへcacheする処理が行われていなかった問題の修正

### DIFF
--- a/mrblib/connection.rb
+++ b/mrblib/connection.rb
@@ -46,7 +46,7 @@ module Msd
             s.cache(key, value)
           },
           Proc.new { s.before_cache_retry }
-        ) if s != klass
+        ) unless s == klass
       end
     end
 

--- a/mrblib/connection.rb
+++ b/mrblib/connection.rb
@@ -46,7 +46,7 @@ module Msd
             s.cache(key, value)
           },
           Proc.new { s.before_cache_retry }
-        ) if s == klass
+        ) if s != klass
       end
     end
 

--- a/test/msd.rb
+++ b/test/msd.rb
@@ -42,3 +42,17 @@ assert("Msd#fetch") do
 
   assert_equal("value", Msd.fetch("example"))
 end
+
+assert("Msd#fetch_retry") do
+  redis = Msd::Store::Redis.new
+  lmc = Msd::Store::Lmc.new("test")
+
+  Msd.configure do |c|
+    c.stores = [lmc, redis]
+    c.logger = nil
+  end
+  redis.cache("example.com", "1")
+  Msd.fetch("example.com")
+  redis.purge("example.com")
+  assert_equal("1", Msd.fetch("example.com"))
+end

--- a/test/msd.rb
+++ b/test/msd.rb
@@ -52,7 +52,7 @@ assert("Msd#fetch_retry") do
     c.logger = nil
   end
   redis.cache("example.com", "1")
-  Msd.fetch("example.com")
+  assert_equal("1", Msd.fetch("example.com"))
   redis.purge("example.com")
   assert_equal("1", Msd.fetch("example.com"))
 end


### PR DESCRIPTION
[Proc.new内でbreakするとLocalJumpErrorが発生するため、storeが一致する場合はsafe_runをスキップするようにした by tap1ra · Pull Request #5 · pepabo/mruby-msd](https://github.com/pepabo/mruby-msd/pull/5)

上記PRの修正で判定が誤っていた。
クラスが異なる場合にcacheするところを、クラスが一致した場合のみcacheされていた。