### PR TITLE
mruby-mysqlのconnectはundefinedなのでMsdで定義したconnectを呼び出す

### DIFF
--- a/mrblib/store/mysql.rb
+++ b/mrblib/store/mysql.rb
@@ -61,7 +61,7 @@ module Msd
 
       def before_fetch_retry
         @_c.close
-        @_c.connect
+        connect
       end
 
       def before_purge_retry;end


### PR DESCRIPTION
`before call:undefined method 'connect' for #<MySQL::Database` が出力されていた