### PR TITLE
MySQLクラスではdisconnectを定義しているのでretry処理でそちらを使用する

### DIFF
--- a/mrblib/store/mysql.rb
+++ b/mrblib/store/mysql.rb
@@ -25,6 +25,7 @@ module Msd
       end
 
       def disconnect
+        @_c.close
         @_c = nil
       end
 
@@ -56,11 +57,11 @@ module Msd
       end
 
       def before_connect_retry
-        @_c.close
+        disconnect
       end
 
       def before_fetch_retry
-        @_c.close
+        disconnect
         connect
       end
 

--- a/mrblib/store/mysql.rb
+++ b/mrblib/store/mysql.rb
@@ -25,8 +25,11 @@ module Msd
       end
 
       def disconnect
-        @_c.close
-        @_c = nil
+        begin
+          @_c.close
+        ensure
+          @_c = nil
+        end
       end
 
       def fetch(key)


### PR DESCRIPTION
MySQLクラスにおいてdisconnect実行時にコネクションをクローズし、接続インスタンスは明示的にnilを代入するように変更。
retry時に実行する切断処理では自クラス内で定義されたdisconnectを使用するように変更した