### PR TITLE
mysql.executeはプリペアドステートメントで複数の引数を受ける可能性があるため、可変長にする

### DIFF
--- a/mrblib/store/mysql.rb
+++ b/mrblib/store/mysql.rb
@@ -35,7 +35,7 @@ module Msd
       def fetch(key)
         key = set_prefix(key)
         connect unless connect?
-        rows = @_c.execute(@query, key)
+        rows = @_c.execute(@query, *key)
         cols = rows.next
         rows.close
         if cols


### PR DESCRIPTION
以下のように複数の `?` を持ったクエリの場合、動作できないため複数キーを渡せるように変更します。

```sql
select * from sample where col in (?, ?);
```

mruby-mysqlの `execute` は埋め込む値を可変長で渡せるため `mysql.execute(query, *key)` の形で呼び出すよう変更しています。

keyが複数に渡る時は配列に変換する必要があるため、その場合は `set_prefix` を以下のようにオーバーライドし `fetch('key1,key2)` と渡せるようにします。

```ruby
def set_prefix(key)
  key.split(',')
end
```
