### PR TITLE
mruby-mock is necessary for testing only

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,11 +5,11 @@ MRuby::Gem::Specification.new('mruby-msd') do |spec|
   spec.add_dependency 'mruby-cache',  github:'matsumoto-r/mruby-localmemcache'
   spec.add_dependency 'mruby-env',  github: 'iij/mruby-env'
   spec.add_dependency 'mruby-mysql', github: 'mattn/mruby-mysql'
-  spec.add_dependency 'mruby-mock', github: 'iij/mruby-mock'
   spec.add_dependency 'mruby-redis'
   spec.add_dependency 'mruby-json'
   spec.add_dependency 'mruby-env'
   spec.add_dependency 'mruby-mutex'
   spec.add_test_dependency 'mruby-array-ext'
   spec.add_test_dependency 'mruby-print'
+  spec.add_test_dependency 'mruby-mock', github: 'iij/mruby-mock'
 end


### PR DESCRIPTION
The following code of mruby-mock interferes with production code.

  - https://github.com/iij/mruby-mock/blob/master/mrblib/test_double.rb#L67

Build in this code to mruby

  ```ruby
  BasicObject.class_eval {}
  ```

Then, I'm not expect.

  ```ruby
  n = 0
  3.times { n += 1 }
  puts n
  # => 0 (I want 3)
  ```

The current namespace separates from the namespace in the block.