### PR TITLE
discard Redis object if Redis#close fail

### DIFF
--- a/mrblib/store/redis.rb
+++ b/mrblib/store/redis.rb
@@ -23,6 +23,8 @@ module Msd
 
       def close
         @_c.close
+      rescue
+        @c = nil
       end
 
       def fetch(key)


### PR DESCRIPTION
If `Redis#close` fails, there is no way to save it, so we will destroy the object.

For example:

  * Redis context died (https://github.com/matsumotory/mruby-redis/blob/master/src/mrb_redis.c#L1430)

After Redis object is destroyed, it is reconnected by the following process.

  * https://github.com/pepabo/mruby-msd/blob/master/mrblib/store/redis.rb#L14-L16

