### PR TITLE
Fixed some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,13 @@ install:
   - sudo apt-get -qq install rake bison git gperf redis-server
 script:
   - rake test
+before_script:
+  - redis-server --port 6379 &
+  - redis-server --port 6380 --requirepass 'secret' &
+  - redis-server --cluster-enabled yes --cluster-config-file 7000-nodes.conf --port 7000 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7001-nodes.conf --port 7001 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7002-nodes.conf --port 7002 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7003-nodes.conf --port 7003 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7004-nodes.conf --port 7004 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7005-nodes.conf --port 7005 &
+  - echo yes | redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005

--- a/test/cache.rb
+++ b/test/cache.rb
@@ -16,20 +16,20 @@ end
 
 assert("Msd::Store::Lmc.connect") do
   lmc = Msd::Store::Lmc.new("test")
-  assert_true lmc.connect != nil
+  assert_not_nil lmc.connect
 end
 
 assert("Msd::Store::Lmc.connect?") do
   lmc = Msd::Store::Lmc.new("test")
   assert_false lmc.connect?
   lmc.connect
-  assert_true lmc.connect? != nil
+  assert_not_nil lmc.connect?
 end
 
 assert("Msd::Store::Lmc.drop") do
   lmc = Msd::Store::Lmc.new("test")
   lmc.connect
-  assert_true lmc.connect? != nil
+  assert_not_nil lmc.connect?
   lmc.drop
   assert_false lmc.connect?
 end

--- a/test/cache.rb
+++ b/test/cache.rb
@@ -16,20 +16,20 @@ end
 
 assert("Msd::Store::Lmc.connect") do
   lmc = Msd::Store::Lmc.new("test")
-  assert_true lmc.connect
+  assert_true lmc.connect != nil
 end
 
 assert("Msd::Store::Lmc.connect?") do
   lmc = Msd::Store::Lmc.new("test")
   assert_false lmc.connect?
   lmc.connect
-  assert_true lmc.connect?
+  assert_true lmc.connect? != nil
 end
 
 assert("Msd::Store::Lmc.drop") do
   lmc = Msd::Store::Lmc.new("test")
   lmc.connect
-  assert_true lmc.connect?
+  assert_true lmc.connect? != nil
   lmc.drop
   assert_false lmc.connect?
 end

--- a/test/mysql.rb
+++ b/test/mysql.rb
@@ -25,8 +25,8 @@ end
 assert("Msd::Store::MySQL.connect") do
   s = subject
   s.set_mysql_class(mock('1'))
-  assert_true s.connect != nil
-  assert_true s.connect? != nil
+  assert_not_nil s.connect
+  assert_not_nil s.connect?
 end
 
 assert("Msd::Store::MySQL.fetch") do

--- a/test/mysql.rb
+++ b/test/mysql.rb
@@ -25,8 +25,8 @@ end
 assert("Msd::Store::MySQL.connect") do
   s = subject
   s.set_mysql_class(mock('1'))
-  assert_true s.connect
-  assert_true s.connect?
+  assert_true s.connect != nil
+  assert_true s.connect? != nil
 end
 
 assert("Msd::Store::MySQL.fetch") do

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -13,21 +13,21 @@ end
 
 assert("Msd::Store::Redis.connect") do
   redis = Msd::Store::Redis.new
-  assert_true redis.connect != nil
+  assert_not_nil redis.connect
 end
 
 assert("Msd::Store::Redis.connect?") do
   redis = Msd::Store::Redis.new
   assert_false redis.connect?
   redis.connect
-  assert_true redis.connect? != nil
+  assert_not_nil redis.connect?
 end
 
 assert("Msd::Store::Redis.close") do
   redis = Msd::Store::Redis.new
   redis.set_mock
   redis.connect
-  assert_true redis.connect?
+  assert_not_nil redis.connect?
   redis.close
   assert_false redis.connect?
 end

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -13,14 +13,14 @@ end
 
 assert("Msd::Store::Redis.connect") do
   redis = Msd::Store::Redis.new
-  assert_true redis.connect
+  assert_true redis.connect != nil
 end
 
 assert("Msd::Store::Redis.connect?") do
   redis = Msd::Store::Redis.new
   assert_false redis.connect?
   redis.connect
-  assert_true redis.connect?
+  assert_true redis.connect? != nil
 end
 
 assert("Msd::Store::Redis.close") do


### PR DESCRIPTION
Hi. cc @pyama86 

Fixed some tests

### `assert_true` is strict since mruby-2.0.1

These are failed tests:

```
Fail: Msd::Store::Lmc.connect (mrbgems: mruby-msd)
 - Assertion[1]
    Expected #<Cache:0xd76d60> to be true.
Fail: Msd::Store::Lmc.connect? (mrbgems: mruby-msd)
 - Assertion[2]
    Expected #<Cache:0xd81560> to be true.
Fail: Msd::Store::Lmc.drop (mrbgems: mruby-msd)
 - Assertion[1]
    Expected #<Cache:0xd80c30> to be true.
Fail: Msd::Store::MySQL.connect (mrbgems: mruby-msd)
 - Assertion[1]
    Expected #<Mocks::Mock:0xd76fa0> to be true.
 - Assertion[2]
    Expected #<Mocks::Mock:0xd76fa0> to be true.
Fail: Msd::Store::Redis.connect (mrbgems: mruby-msd)
 - Assertion[1]
    Expected #<Redis:0xd76f10> to be true.
```

Check not nil.

### mruby-redis supported `Redis#asking` `Redis#cluster`

ref: https://github.com/matsumotory/mruby-redis/pull/99

These are failed tests:

```
Redis::ConnectionError: Redis#asking => redis connection failed. (mrbgems: mruby-redis)
Redis::ConnectionError: Redis#cluster => redis connection failed. (mrbgems: mruby-redis)
```

Fixed test environment.

### `Float#to_s` CRuby compatible in mruby 2.0.1

These are failed tests:

```
Fail: stringify object with boolean key and float value (mrbgems: mruby-json)
 - Assertion[1]
    Expected: "{\"true\":5}"
      Actual: "{\"true\":5.0}"
```

 Now on discation : https://github.com/mattn/mruby-json/pull/40

This PR remains a failure of this test. 
I want to ignore that test temporarily.
