### PR TITLE
fix connection error

### DIFF
--- a/mrblib/store/redis.rb
+++ b/mrblib/store/redis.rb
@@ -12,17 +12,17 @@ module Msd
       end
 
       def connect
-        @_c ||= @klass.new(@host, @port, @timeout)
+        @_c = @klass.new(@host, @port, @timeout)
       end
 
       def connect?
-        @_c.ping
+        @_c ? @_c.ping : false
       rescue
         false
       end
 
       def close
-        @_c.close
+        @_c.close if @_c
       rescue
         @c = nil
       end


### PR DESCRIPTION
Connect using an invalid object and it sometimes failed, so change to create an object each time connect is called.

error message
> connection is already closed or not initialized yet.
refs: https://github.com/matsumotory/mruby-redis/blob/master/src/mrb_redis.c#L1448