### PR TITLE
FIX #14 redisのclose時にnil代入する

### DIFF
--- a/mrblib/store/redis.rb
+++ b/mrblib/store/redis.rb
@@ -23,8 +23,9 @@ module Msd
 
       def close
         @_c.close
+        @_c = nil
       rescue
-        @c = nil
+        @_c = nil
       end
 
       def fetch(key)


### PR DESCRIPTION
redisのclose時にオブジェクト が開放されていなかったので、開放します。